### PR TITLE
Update nats request usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     license='Apache 2 License',
     packages=['stan', 'stan.aio', 'stan.pb'],
     zip_safe=True,
-    install_requires=['protobuf>=3.4','asyncio-nats-client>=0.5.0'],
+    install_requires=['protobuf>=3.4','asyncio-nats-client>=0.7.0'],
 )

--- a/stan/aio/client.py
+++ b/stan/aio/client.py
@@ -135,7 +135,7 @@ class Client:
 
         msg = None
         try:
-            msg = await self._nc.timed_request(
+            msg = await self._nc.request(
                 self._discover_subject,
                 payload,
                 timeout=self._connect_timeout,
@@ -401,7 +401,7 @@ class Client:
         req.subject = subject
         req.inbox = sub.inbox
 
-        msg = await self._nc.timed_request(
+        msg = await self._nc.request(
             self._sub_req_subject,
             req.SerializeToString(),
             self._connect_timeout,
@@ -461,7 +461,7 @@ class Client:
 
         req = protocol.CloseRequest()
         req.clientID = self._client_id
-        msg = await self._nc.timed_request(
+        msg = await self._nc.request(
             self._close_req_subject,
             req.SerializeToString(),
             self._connect_timeout,
@@ -527,7 +527,7 @@ class Subscription(object):
         if self.durable_name is not None:
             req.durableName = self.durable_name
 
-        msg = await self._nc.timed_request(
+        msg = await self._nc.request(
             self._sc._unsub_req_subject,
             req.SerializeToString(),
             self._sc._connect_timeout,
@@ -560,7 +560,7 @@ class Subscription(object):
         if self.durable_name is not None:
             req.durableName = self.durable_name
 
-        msg = await self._nc.timed_request(
+        msg = await self._nc.request(
             self._sc._sub_close_req_subject,
             req.SerializeToString(),
             self._sc._connect_timeout,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -20,7 +20,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_connect(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", "client-123", nats=nc)
@@ -44,7 +44,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_sync_publish_and_acks(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -69,7 +69,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_async_publish_and_acks(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -106,7 +106,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_async_publish_and_max_acks_inflight(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(),
@@ -149,7 +149,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_subscribe_receives_new_messages(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -188,7 +188,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_unsubscribe_from_new_messages(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -230,7 +230,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_receiving_multiple_subscriptions(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -296,7 +296,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_closes_cleans_subscriptions(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         await sc.connect("test-cluster", generate_client_id(), nats=nc)
@@ -344,7 +344,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_connecting_with_dup_id(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         client_id = generate_client_id()
@@ -399,7 +399,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_connect_timeout_wrong_cluster(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         sc = STAN()
         client_id = generate_client_id()
@@ -414,7 +414,7 @@ class ClientTest(SingleServerTestCase):
     @async_test
     async def test_missing_hb_response_replaces_client(self):
         nc = NATS()
-        await nc.connect(io_loop=self.loop)
+        await nc.connect(loop=self.loop)
 
         class STAN2(STAN):
             def __init__(self):
@@ -486,18 +486,18 @@ class ClientTest(SingleServerTestCase):
     async def test_reconnect_without_graceful_close(self):
         client_id = generate_client_id()
 
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             # Will timeout as NATS Streaming server considers it
             # continue to be connected...
             with self.assertRaises(ErrConnectReqTimeout):
                 sc = STAN()
                 await sc.connect("test-cluster", client_id, nats=nc, connect_timeout=0.25)
 
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             # Will timeout as NATS Streaming server considers it
             # continue to be connected since too soon...
             with self.assertRaises(StanError):
@@ -507,7 +507,7 @@ class ClientTest(SingleServerTestCase):
         # If we space out the reconnects then the server will stop
         # detecting the previous instances of the client.
         await asyncio.sleep(1, loop=self.loop)
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             # Will timeout as NATS Streaming server considers it
             # continue to be connected...
             with self.assertRaises(ErrConnectReqTimeout):
@@ -515,7 +515,7 @@ class ClientTest(SingleServerTestCase):
                 await sc.connect("test-cluster", client_id, nats=nc, connect_timeout=0.25)
 
         await asyncio.sleep(1, loop=self.loop)
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             # Will not timeout as NATS Streaming server considers it
             # continue to be connected...
             sc = STAN()
@@ -577,7 +577,7 @@ class SubscriptionsTest(SingleServerTestCase):
             pmsgs.append(msg)
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -603,7 +603,7 @@ class SubscriptionsTest(SingleServerTestCase):
             await sc.close()
 
         await asyncio.sleep(1, loop=self.loop)
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc, connect_timeout=10)
 
@@ -665,7 +665,7 @@ class SubscriptionsTest(SingleServerTestCase):
             pmsgs.append(msg)
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -725,7 +725,7 @@ class SubscriptionsTest(SingleServerTestCase):
             sc = STAN()
 
             client_id = "{}-{}".format(generate_client_id(), chr(letter))
-            await nc.connect(name=client_id, io_loop=self.loop)
+            await nc.connect(name=client_id, loop=self.loop)
             await sc.connect("test-cluster", client_id, nats=nc)
             clients[client_id] = Component(nc, sc)
 
@@ -795,7 +795,7 @@ class SubscriptionsTest(SingleServerTestCase):
             pmsgs.append(msg)
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -870,7 +870,7 @@ class SubscriptionsTest(SingleServerTestCase):
             pmsgs.append(msg)
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -922,7 +922,7 @@ class SubscriptionsTest(SingleServerTestCase):
         pmsgs  = [] # Plain subscription messages
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -952,7 +952,7 @@ class SubscriptionsTest(SingleServerTestCase):
         pmsgs  = [] # Plain subscription messages
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -983,7 +983,7 @@ class SubscriptionsTest(SingleServerTestCase):
         pmsgs  = [] # Plain subscription messages
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -1011,7 +1011,7 @@ class SubscriptionsTest(SingleServerTestCase):
         pmsgs  = [] # Plain subscription messages
 
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -1038,7 +1038,7 @@ class SubscriptionsTest(SingleServerTestCase):
     @async_test
     async def test_subscribe_error_callback(self):
         client_id = generate_client_id()
-        with (await nats.connect(io_loop=self.loop)) as nc:
+        with (await nats.connect(loop=self.loop)) as nc:
             sc = STAN()
             await sc.connect("test-cluster", client_id, nats=nc)
 
@@ -1069,7 +1069,7 @@ class SubscriptionsTest(SingleServerTestCase):
     async def test_subscribe_error_callback_fails(self):
         client_id = generate_client_id()
         with (
-            await nats.connect(io_loop=self.loop)
+            await nats.connect(loop=self.loop)
         ) as nc, self.assertLogs(
             'stan.aio.client', level='ERROR'
         ) as logs:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -172,7 +172,7 @@ class ClientTest(SingleServerTestCase):
             await sc.publish("hi", b'hello')
 
         try:
-            asyncio.wait_for(future, 2, loop=self.loop)
+            await asyncio.wait_for(future, 2, loop=self.loop)
         except:
             pass
 
@@ -214,7 +214,7 @@ class ClientTest(SingleServerTestCase):
             await sc.publish("hi", b'hello')
 
         try:
-            asyncio.sleep(2, loop=self.loop)
+            await asyncio.sleep(2, loop=self.loop)
         except:
             pass
 
@@ -319,7 +319,7 @@ class ClientTest(SingleServerTestCase):
             await sc.publish("hi", b'hello')
 
         try:
-            asyncio.wait_for(future, 2, loop=self.loop)
+            await asyncio.wait_for(future, 2, loop=self.loop)
         except:
             pass
 
@@ -332,7 +332,7 @@ class ClientTest(SingleServerTestCase):
         await sc.close()
 
         # Should have removed acks and HBs subscriptions.
-        self.assertEqual(len(nc._subs), 0)
+        self.assertEqual(len(nc._subs), 1)
         self.assertEqual(sc._hb_inbox, None)
         self.assertEqual(sc._hb_inbox_sid, None)
         self.assertEqual(sc._ack_subject, None)
@@ -372,7 +372,7 @@ class ClientTest(SingleServerTestCase):
             await sc.publish("hi", b'hello')
 
         try:
-            asyncio.wait_for(future, 2, loop=self.loop)
+            await asyncio.wait_for(future, 2, loop=self.loop)
         except:
             pass
 
@@ -385,7 +385,7 @@ class ClientTest(SingleServerTestCase):
         await sc.close()
 
         # Should have removed acks and HBs subscriptions.
-        self.assertEqual(len(nc._subs), 0)
+        self.assertEqual(len(nc._subs), 1)
         scs = [sc, sc_2]
         for s in scs:
             self.assertEqual(s._hb_inbox, None)
@@ -406,7 +406,7 @@ class ClientTest(SingleServerTestCase):
 
         with self.assertRaises(ErrConnectReqTimeout):
             await sc.connect("test-cluster-missing", client_id,
-                             nats=nc, connect_timeout=0.1)
+                             nats=nc, connect_timeout=0.3)
 
         await nc.close()
         self.assertFalse(nc.is_connected)
@@ -452,7 +452,7 @@ class ClientTest(SingleServerTestCase):
             await sc.publish("hi", b'hello')
 
         try:
-            asyncio.wait_for(future, 2, loop=self.loop)
+            await asyncio.wait_for(future, 2, loop=self.loop)
         except:
             pass
 
@@ -477,7 +477,7 @@ class ClientTest(SingleServerTestCase):
             self.assertEqual(s._ack_subject_sid, None)
 
         # Should have removed acks and HBs subscriptions.
-        self.assertEqual(len(nc._subs), 0)
+        self.assertEqual(len(nc._subs), 1)
 
         await nc.close()
         self.assertFalse(nc.is_connected)
@@ -539,7 +539,7 @@ class ClientTest(SingleServerTestCase):
                 await sc.publish("hi", b'hello')
 
             try:
-                asyncio.wait_for(future, 2, loop=self.loop)
+                await asyncio.wait_for(future, 2, loop=self.loop)
             except:
                 pass
 


### PR DESCRIPTION
- Use request that uses a wildcard subscription for req/reply protocol
- Bump version of the nats client to 0.7.0
- Update tests